### PR TITLE
possible fix for multi threading

### DIFF
--- a/cl-mock-basic.asd
+++ b/cl-mock-basic.asd
@@ -7,9 +7,9 @@
   :long-description "Mocking library to test plain functions."
   :author "Olof-Joachim Frahm <olof@macrolet.net>"
   :license "AGPL-3+"
-  :version "1.0.0"
+  :version "1.1.0"
   #+asdf-unicode :encoding #+asdf-unicode :utf-8
-  :depends-on (#:closer-mop #:alexandria)
+  :depends-on (#:closer-mop #:alexandria #:bordeaux-threads)
   :in-order-to ((asdf:test-op (asdf:load-op #:cl-mock-tests-basic)))
   :perform (asdf:test-op :after (op c)
              (funcall (find-symbol (symbol-name '#:run!) '#:fiveam)

--- a/cl-mock.asd
+++ b/cl-mock.asd
@@ -1,13 +1,13 @@
 ;; -*- mode: lisp; syntax: common-lisp; coding: utf-8-unix; package: cl-user; -*-
 
 (in-package #:cl-user)
-
+
 (asdf:defsystem #:cl-mock
   :description "Mocking library"
   :long-description "Mocking library to test plain functions (extended version)."
   :author "Olof-Joachim Frahm <olof@macrolet.net>"
   :license "AGPL-3+"
-  :version "1.0.1"
+  :version "1.1.0"
   #+asdf-unicode :encoding #+asdf-unicode :utf-8
   :depends-on (#:cl-mock-basic #:trivia)
   :in-order-to ((asdf:test-op (asdf:load-op #:cl-mock-tests)))


### PR DESCRIPTION
I was trying a bit.
This seems to work. Though in a really multi-threaded environment `*recordp*` and more seriously `*invocations*` will probably have incorrect values. I'm wondering if `*invocations*` should be 'locked' or be an atomic variable.